### PR TITLE
Allow for implicit texture sampling from compute

### DIFF
--- a/source/opt/replace_invalid_opc.cpp
+++ b/source/opt/replace_invalid_opc.cpp
@@ -81,7 +81,10 @@ bool ReplaceInvalidOpcodePass::RewriteFunction(Function* function,
 
         bool replace = false;
         if (model != spv::ExecutionModel::Fragment &&
-            IsFragmentShaderOnlyInstruction(inst)) {
+// UE Change Begin: Allow for implicit texture sampling from compute since we support DerivativeGroupLinearNV (SPIRV-Tools issue #5674)
+          model != spv::ExecutionModel::GLCompute &&
+// UE Change End: Allow for implicit texture sampling from compute since we support DerivativeGroupLinearNV (SPIRV-Tools issue #5674)
+          IsFragmentShaderOnlyInstruction(inst)) {
           replace = true;
         }
 


### PR DESCRIPTION
Allow for implicit texture sampling from compute since we support DerivativeGroupLinearNV